### PR TITLE
Update LibertyBans to 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>space.arim.libertybans</groupId>
             <artifactId>bans-api</artifactId>
-            <version>0.7.6</version>
+            <version>1.0.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/eu/mcdb/ban_announcer/listener/LibertyBansListener.java
+++ b/src/main/java/eu/mcdb/ban_announcer/listener/LibertyBansListener.java
@@ -9,6 +9,7 @@ import eu.mcdb.ban_announcer.BanAnnouncerPlugin;
 import eu.mcdb.ban_announcer.PunishmentAction;
 import eu.mcdb.ban_announcer.PunishmentListener;
 import space.arim.libertybans.api.AddressVictim;
+import space.arim.libertybans.api.CompositeVictim;
 import space.arim.libertybans.api.LibertyBans;
 import space.arim.libertybans.api.Operator;
 import space.arim.libertybans.api.Operator.OperatorType;
@@ -78,7 +79,7 @@ public class LibertyBansListener extends PunishmentListener {
                 ? getAnnouncer().getConfig().getConsoleName()
                 : getOperatorName(operator);
 
-        punishment.setId(Integer.toString(pun.getID()));
+        punishment.setId(Long.toString(pun.getIdentifier()));
         punishment.setOperator(operatorName);
         punishment.setPlayer(getVictimName(pun.getVictim()));
         punishment.setReason(pun.getReason());
@@ -139,6 +140,9 @@ public class LibertyBansListener extends PunishmentListener {
         }
         if (victim.getType() == VictimType.ADDRESS) {
             return ((AddressVictim) victim).getAddress().toInetAddress().getHostAddress();
+        }
+        if (victim.getType() == VictimType.COMPOSITE) {
+            return getPlayerName(((CompositeVictim) victim).getUUID());
         }
         return "<Unknown>";
     }


### PR DESCRIPTION
- Adds support for Composite Punishments
- `getId()` is deprecated, use `getIdentifier()` instead